### PR TITLE
Layout statusbarView with AutoLayout to fix the issue for iPads lands…

### DIFF
--- a/StatusBarExample/ViewController.swift
+++ b/StatusBarExample/ViewController.swift
@@ -16,9 +16,16 @@ class ViewController: UIViewController {
             let app = UIApplication.shared
             let statusBarHeight: CGFloat = app.statusBarFrame.size.height
             
-            let statusbarView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: statusBarHeight))
+            let statusbarView = UIView()
             statusbarView.backgroundColor = UIColor.red
             view.addSubview(statusbarView)
+          
+            statusbarView.translatesAutoresizingMaskIntoConstraints = false
+            statusbarView.heightAnchor.constraint(equalToConstant: statusBarHeight).isActive = true
+            statusbarView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1.0).isActive = true
+            statusbarView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            statusbarView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+          
         } else {
             let statusBar = UIApplication.shared.value(forKeyPath: "statusBarWindow.statusBar") as? UIView
             statusBar?.backgroundColor = UIColor.red


### PR DESCRIPTION
This PR fixes the issue on iPads.

The issue can be reproduced:
1. Run the app on iPad portrait
2. Rotate the iPad to landscape
3. You can see that status bar is cropped and corrupted.

This happens because status bar frame isn't recalculated on iPad rotations.

I added Auto Layout constraints that fixes the mentioned issue.